### PR TITLE
Add dkim records

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Terraform module to setup AWS SES.
 
 * \[`domain`\]: String(required): Domain to use for SES.
 * \[`zone_id`\]: String(optional): Route 53 zone ID for the SES domain verification. If the `zone_id` is not set, we do not create verification record in R53.
+* \[`dkim_records`\]: Map(optional): Amazon SES DKIM records to add to R53. You can generate these records from the AWS console.
 
 ## Output
 
@@ -18,5 +19,10 @@ module "ses" {
   source  = "../../modules/ses"
   domain  = "${var.domain_name}"
   zone_id = "${aws_route53_zone.zone.zone_id}"
+  dkim_records = {
+    "one._domainkey.example.com"   = "one.dkim.amazonses.com"
+    "two._domainkey.example.com"   = "two.dkim.amazonses.com"
+    "three._domainkey.example.com" = "three.dkim.amazonses.com"
+  }
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,3 @@
 resource "aws_ses_domain_identity" "domain" {
   domain = "${var.domain}"
 }
-
-resource "aws_route53_record" "domain_amazonses_verification_record" {
-  count   = "${var.zone_id != "" ? 1 : 0}"
-  zone_id = "${var.zone_id}"
-  name    = "_amazonses.${var.domain}"
-  type    = "TXT"
-  ttl     = "3600"
-  records = ["${aws_ses_domain_identity.domain.verification_token}"]
-}

--- a/r53.tf
+++ b/r53.tf
@@ -1,0 +1,17 @@
+resource "aws_route53_record" "domain_amazonses_verification_record" {
+  count   = "${var.zone_id != "" ? 1 : 0}"
+  zone_id = "${var.zone_id}"
+  name    = "_amazonses.${var.domain}"
+  type    = "TXT"
+  ttl     = "3600"
+  records = ["${aws_ses_domain_identity.domain.verification_token}"]
+}
+
+resource "aws_route53_record" "domain_amazonses_dkim_record" {
+  count   = "${length(var.dkim_records)}"
+  zone_id = "${var.zone_id}"
+  name    = "${element(keys(var.dkim_records), count.index)}"
+  type    = "CNAME"
+  ttl     = "3600"
+  records = ["${element(values(var.dkim_records), count.index)}"]
+}

--- a/r53.tf
+++ b/r53.tf
@@ -8,7 +8,7 @@ resource "aws_route53_record" "domain_amazonses_verification_record" {
 }
 
 resource "aws_route53_record" "domain_amazonses_dkim_record" {
-  count   = "${length(var.dkim_records)}"
+  count   = "${var.zone_id != "" ? length(var.dkim_records) : 0}"
   zone_id = "${var.zone_id}"
   name    = "${element(keys(var.dkim_records), count.index)}"
   type    = "CNAME"

--- a/variables.tf
+++ b/variables.tf
@@ -6,3 +6,9 @@ variable "zone_id" {
   description = "Route 53 zone ID for the SES domain verification"
   default     = ""
 }
+
+variable "dkim_records" {
+  description = "Amazon SES DKIM records to add to R53"
+  type        = "map"
+  default     = {}
+}


### PR DESCRIPTION
Allows to set SES' DKIM records.

```
  + module.ses.aws_route53_record.domain_amazonses_dkim_record[0]
      fqdn:               "<computed>"
      name:               "one._domainkey.example.com"
      records.#:          "1"
      records.3153782229: "one.dkim.amazonses.com"
      ttl:                "3600"
      type:               "CNAME"
      zone_id:            "foo"

  + module.ses.aws_route53_record.domain_amazonses_dkim_record[1]
      fqdn:               "<computed>"
      name:               "two._domainkey.example.com"
      records.#:          "1"
      records.1310579673: "two.dkim.amazonses.com"
      ttl:                "3600"
      type:               "CNAME"
      zone_id:            "foo"

  + module.ses.aws_route53_record.domain_amazonses_dkim_record[2]
      fqdn:              "<computed>"
      name:              "three._domainkey.example.com"
      records.#:         "1"
      records.175018402: "three.dkim.amazonses.com"
      ttl:               "3600"
      type:              "CNAME"
      zone_id:           "foo"
```